### PR TITLE
SVCPLAN-5555: Add support for SUSE

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -129,21 +129,25 @@ class telegraf::install {
           extract_command => 'tar xfz %s --strip-components=2',
           extract_path    => $telegraf::archive_install_dir,
           source          => $telegraf::archive_location,
+          creates         => "${telegraf::archive_install_dir}/usr/bin/telegraf",
           cleanup         => true,
           require         => File[$telegraf::archive_install_dir],
         }
-        file { '/etc/telegraf':
-          ensure => directory,
-        }
-        if $telegraf::manage_user {
-          group { $telegraf::config_file_group:
-            ensure => present,
-          }
-          user { $telegraf::config_file_owner:
-            ensure => present,
-            gid    => $telegraf::config_file_group,
-          }
-        }
+        #ensure_resource( 'file', '/etc/telegraf', { ensure => 'directory', } )
+        #file { '/etc/telegraf':
+        #  ensure => directory,
+        #}
+        #if $telegraf::manage_user {
+        #  ensure_resource( 'group', $telegraf::config_file_group, { ensure => 'present', } )
+        #  group { $telegraf::config_file_group:
+        #    ensure => present,
+        #  }
+        #  ensure_resource( 'user', $telegraf::config_file_owner, { ensure => 'present', gid => $telegraf::config_file_group, } )
+        #  user { $telegraf::config_file_owner:
+        #    ensure => present,
+        #    gid    => $telegraf::config_file_group,
+        #  }
+        #}
         file { '/etc/systemd/system/telegraf.service':
           ensure => file,
           source => 'puppet:///modules/telegraf/telegraf.service',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,17 @@
 # A set of default parameters for Telegraf's configuration.
 #
 class telegraf::params {
+  case $facts['architecture'] {
+    'x86_64': {
+      $archive_architecture  = 'amd64'
+    }
+    'AArch64': {
+      $archive_architecture  = 'arm64'
+    } 
+    default: {
+      $archive_architecture  = 'amd64'
+    } 
+  }
   case $facts['os']['family'] {
     'Darwin': {
       $config_file          = '/usr/local/etc/telegraf/telegraf.conf'
@@ -76,8 +87,9 @@ class telegraf::params {
       $manage_archive       = true
       $manage_user          = true
       $archive_install_dir  = '/opt/telegraf'
-      $archive_version      = '1.15.2'
-      $archive_location     = "https://dl.influxdata.com/telegraf/releases/telegraf-${archive_version}_linux_amd64.tar.gz"
+      # LOOK TO SEE IF telegraf::archive_version SPECIFIED IN HIERA, OTHERWISE USE DEFAULT VERSION
+      $archive_version      = lookup('telegraf::archive_version', String, 'first', '1.31.0')
+      $archive_location     = "https://dl.influxdata.com/telegraf/releases/telegraf-${archive_version}_linux_${archive_architecture}.tar.gz"
       $repo_location        = 'https://repos.influxdata.com/'
       $service_enable       = true
       $service_ensure       = running


### PR DESCRIPTION
This is tested on `control-test-opensuse155a`.

```
Update params for Suse to support hardware architecture (i.e. support Arm 64)
Update params for Suse to have archive_version lookup telegraf::archive_version or default value
Port from upstream module to have install for Suse to include the creates parameter
```

PDK validation does not work on this module, so it will be left as it.